### PR TITLE
TestRailException in doFillTestrailSuiteItems()

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/testrail/TestRailNotifier.java
+++ b/src/main/java/org/jenkinsci/plugins/testrail/TestRailNotifier.java
@@ -287,7 +287,6 @@ public class TestRailNotifier extends Notifier {
                 }
             } catch (ElementNotFoundException e) {
             } catch (IOException e) {
-            } catch (TestRailException e) {
             }
 
             return items;


### PR DESCRIPTION
Remove catch TestRailException in that method
For https://github.com/jenkinsci/testrail-plugin/issues/8

Avoid error message:

    TestRailNotifier.java:[290,15] exception TestRailException
    is never thrown in body of corresponding try statement