### PR TITLE
Result: test elapse for value 0, not just null

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/testrail/TestRailObjects/Result.java
+++ b/src/main/java/org/jenkinsci/plugins/testrail/TestRailObjects/Result.java
@@ -45,7 +45,7 @@ public class Result {
     public String getComment() { return this.comment; }
 
     public String getElapsedTimeString() {
-        int time = (elapsed == null) ? 1 : elapsed.intValue();
+        int time = (elapsed == null || elapsed.intValue() == 0) ? 1 : elapsed.intValue();
 
         return time + "s";
     }


### PR DESCRIPTION
Avoid error when Test Result has an elapsedtime of 0
(test takes less than one second)

    Field :results.elapsed is not in a valid time span format

This fix returns 1 both in case of a null elapsed time, and
when elapsed time is equals to 0.

For issue https://github.com/jenkinsci/testrail-plugin/issues/12