### PR TITLE
fixed JAXB case sensitive issue

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/testrail/JUnit/TestSuite.java
+++ b/src/main/java/org/jenkinsci/plugins/testrail/JUnit/TestSuite.java
@@ -26,7 +26,7 @@ import java.util.List;
 /**
  * Created by Drew on 3/24/2014.
  */
-@XmlRootElement
+@XmlRootElement(name="testsuite")
 public class TestSuite {
     private String name;
     private int failures;

--- a/src/main/java/org/jenkinsci/plugins/testrail/JUnit/TestSuites.java
+++ b/src/main/java/org/jenkinsci/plugins/testrail/JUnit/TestSuites.java
@@ -7,7 +7,7 @@ import java.util.List;
 /**
  * Created by achikin on 7/29/14.
  */
-@XmlRootElement
+@XmlRootElement(name="testsuites")
 public class TestSuites {
     private int failures;
     private int errors;


### PR DESCRIPTION
Adding the name to the @XmlRootElement tag, we are forcing to use this name literally (avoiding the case sensitive issue).

closes #57 

Attached links to check for more info:

https://stackoverflow.com/questions/5097394/how-does-jaxb-map-a-class-name-to-an-xml-element-name

https://javadoc.io/static/org.eclipse.persistence/eclipselink/2.7.3/javax/xml/bind/JAXBContext.html#newInstance-java.lang.Class...-

Regards! :)